### PR TITLE
Update verifyToken.js

### DIFF
--- a/api/utils/verifyToken.js
+++ b/api/utils/verifyToken.js
@@ -15,7 +15,7 @@ export const verifyToken = (req, res, next) => {
 };
 
 export const verifyUser = (req, res, next) => {
-  verifyToken(req, res, next, () => {
+  verifyToken(req, res, () => {
     if (req.user.id === req.params.id || req.user.isAdmin) {
       next();
     } else {
@@ -25,7 +25,7 @@ export const verifyUser = (req, res, next) => {
 };
 
 export const verifyAdmin = (req, res, next) => {
-  verifyToken(req, res, next, () => {
+  verifyToken(req, res, () => {
     if (req.user.isAdmin) {
       next();
     } else {


### PR DESCRIPTION
Removed "next" argument causing no checks on isAdmin.
Basically if the call of `verifyToken` inside of verifyUser / verifyAdmin is successful, the `next()` function would skip the if statement, executing directly the next function.
In my specific case i could update a hotel without being admin.