### PR TITLE
replacing /register to /login

### DIFF
--- a/src/pages/Register.jsx
+++ b/src/pages/Register.jsx
@@ -78,7 +78,7 @@ const Register = () => {
           {err && <span>Something went wrong</span>}
         </form>
         <p>
-          You do have an account? <Link to="/register">Login</Link>
+          You do have an account? <Link to="/login">Login</Link>
         </p>
       </div>
     </div>


### PR DESCRIPTION
It will be /login instead of /register because we are in the register page wanted to go on a login page .